### PR TITLE
Create shorturl for devcontainer wiki

### DIFF
--- a/devcontainer.md
+++ b/devcontainer.md
@@ -1,0 +1,7 @@
+---
+layout: redirected
+sitemap: false
+redirect_to:
+  - https://github.com/sqlcollaborative/dbatools/wiki/DevContainer-Support
+permalink: /devcontainer
+---


### PR DESCRIPTION
Creating `dbatools.io/devconatiner` that will point to the Wiki post created: https://github.com/sqlcollaborative/dbatools/wiki/DevContainer-Support