### PR TITLE
Typo in Set-DbaTempdbConfig-line

### DIFF
--- a/commands/index.html
+++ b/commands/index.html
@@ -812,7 +812,7 @@ To learn how this works, see http://wp.me/PEmnE-Bt
                   <h3><a name="tempdb">tempdb</a></h3>
                   <p>
                     <a href="http://docs.dbatools.io/Get-DbaTempdbUsage">Get-DbaTempdbUsage</a><br>
-                    <a href="http://docs.dbatools.io/Set-DbaTempdbConfig">Set-DbaTempdbConfig</a><br>
+                    <a href="http://docs.dbatools.io/Set-DbaTempDbConfig">Set-DbaTempdbConfig</a><br>
                     <a href="http://docs.dbatools.io/Test-DbaTempDbConfig">Test-DbaTempdbConfig</a>
                   </p>
                   <h3><a name="DataMasking">Data Masking</a></h3>


### PR DESCRIPTION
https://docs.dbatools.io/Set-DbaTempdbConfig => https://docs.dbatools.io/Set-DbaTempDbConfig